### PR TITLE
Use ConnectionProvider and Mono to handle API connectivity.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM gradle:5.3.1-jdk8-alpine as builder
+FROM gradle:5.4.1-jdk8-alpine as builder
 USER root
 COPY . .
 ARG apiVersion
 RUN gradle --no-daemon -PapiVersion=${apiVersion} build
 
-FROM gcr.io/distroless/java
+FROM gcr.io/distroless/java:8
 ENV JAVA_TOOL_OPTIONS -XX:+ExitOnOutOfMemoryError
 COPY --from=builder /home/gradle/build/libs/fint-zendesk-integration-*.jar /data/app.jar
 CMD ["/data/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     compile('no.fint:fint-cache:2.1.1-beta-1') {
         exclude group: 'no.fint'
     }
+    compile("com.github.springfox.loader:springfox-loader:2.0.0")
 
     implementation 'org.apache.commons:commons-lang3:3.9'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.2.4.RELEASE'
+    id 'org.springframework.boot' version '2.1.6.RELEASE'
     id 'java'
     id 'groovy'
     id "com.github.ben-manes.versions" version "0.21.0"
@@ -32,10 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    compile('no.fint:fint-portal-api:3.5.0-beta-1') {
-        exclude group: 'org.springframework'
-        exclude group: 'org.springframework.boot'
-    }
+    compile('no.fint:fint-portal-api:3.5.0-beta-1')
     compile('no.fint:fint-cache:2.1.1-beta-1') {
         exclude group: 'no.fint'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.springframework.boot' version '2.1.6.RELEASE'
+    id 'org.springframework.boot' version '2.2.4.RELEASE'
     id 'java'
     id 'groovy'
     id "com.github.ben-manes.versions" version "0.21.0"
@@ -32,11 +32,13 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
-    compile('no.fint:fint-portal-api:3.5.0-beta-1')
+    compile('no.fint:fint-portal-api:3.5.0-beta-1') {
+        exclude group: 'org.springframework'
+        exclude group: 'org.springframework.boot'
+    }
     compile('no.fint:fint-cache:2.1.1-beta-1') {
         exclude group: 'no.fint'
     }
-    compile("com.github.springfox.loader:springfox-loader:2.0.0")
 
     implementation 'org.apache.commons:commons-lang3:3.9'
 

--- a/src/main/java/no/fint/ApplicationConfiguration.java
+++ b/src/main/java/no/fint/ApplicationConfiguration.java
@@ -66,9 +66,9 @@ public class ApplicationConfiguration {
         log.info("Connection Provider settings: {}", settings);
         switch (StringUtils.upperCase(settings.getType())) {
             case "FIXED":
-                return ConnectionProvider.fixed("Zendesk", settings.getMaxConnections(), settings.getAcquireTimeout(), settings.getMaxIdleTime(), settings.getMaxLifeTime());
+                return ConnectionProvider.fixed("Zendesk", settings.getMaxConnections(), settings.getAcquireTimeout());
             case "ELASTIC":
-                return ConnectionProvider.elastic("Zendesk", settings.getMaxIdleTime(), settings.getMaxLifeTime());
+                return ConnectionProvider.elastic("Zendesk");
             case "NEW":
                 return ConnectionProvider.newConnection();
             default:

--- a/src/main/java/no/fint/ApplicationConfiguration.java
+++ b/src/main/java/no/fint/ApplicationConfiguration.java
@@ -1,21 +1,28 @@
 package no.fint;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import no.fint.provisioning.model.TicketSynchronizationObject;
 import no.fint.provisioning.model.UserSynchronizationObject;
 import no.fint.zendesk.RateLimiter;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorResourceFactory;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunctions;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.resources.ConnectionProvider;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 
 @Configuration
+@Slf4j
 public class ApplicationConfiguration {
 
     @Value("${fint.zendesk.base-url:https://fintlabs.zendesk.com/api/v2/}")
@@ -36,8 +43,15 @@ public class ApplicationConfiguration {
     private int ticketSyncMaxRetryAttempts;
 
     @Bean
-    public WebClient webClient(RateLimiter rateLimiter, RequestLogger requestLogger) {
-        return WebClient.builder()
+    public WebClient webClient(
+            WebClient.Builder builder,
+            ReactorResourceFactory factory,
+            ConnectionProvider connectionProvider,
+            RateLimiter rateLimiter,
+            RequestLogger requestLogger) {
+        factory.setConnectionProvider(connectionProvider);
+        return builder
+                .clientConnector(new ReactorClientHttpConnector(factory, HttpClient::secure))
                 .baseUrl(zenDeskBaseUrl)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE)
                 .filter(ExchangeFilterFunctions.basicAuthentication(username, token))
@@ -45,6 +59,21 @@ public class ApplicationConfiguration {
                 .filter(requestLogger.logRequest())
                 .filter(requestLogger.logResponse())
                 .build();
+    }
+
+    @Bean
+    public ConnectionProvider connectionProvider(ConnectionProviderSettings settings) {
+        log.info("Connection Provider settings: {}", settings);
+        switch (StringUtils.upperCase(settings.getType())) {
+            case "FIXED":
+                return ConnectionProvider.fixed("Zendesk", settings.getMaxConnections(), settings.getAcquireTimeout(), settings.getMaxIdleTime(), settings.getMaxLifeTime());
+            case "ELASTIC":
+                return ConnectionProvider.elastic("Zendesk", settings.getMaxIdleTime(), settings.getMaxLifeTime());
+            case "NEW":
+                return ConnectionProvider.newConnection();
+            default:
+                throw new IllegalArgumentException("Illegal connection provider type: " + settings.getType());
+        }
     }
 
     @Bean

--- a/src/main/java/no/fint/ConnectionProviderSettings.java
+++ b/src/main/java/no/fint/ConnectionProviderSettings.java
@@ -5,8 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 import reactor.netty.resources.ConnectionProvider;
 
-import java.time.Duration;
-
 @ConfigurationProperties("fint.webclient.connection-provider")
 @Component
 @Data
@@ -14,6 +12,4 @@ public class ConnectionProviderSettings {
     private String type = "fixed";
     private int maxConnections = ConnectionProvider.DEFAULT_POOL_MAX_CONNECTIONS;
     private long acquireTimeout = ConnectionProvider.DEFAULT_POOL_ACQUIRE_TIMEOUT;
-    private Duration maxIdleTime;
-    private Duration maxLifeTime;
 }

--- a/src/main/java/no/fint/ConnectionProviderSettings.java
+++ b/src/main/java/no/fint/ConnectionProviderSettings.java
@@ -1,0 +1,19 @@
+package no.fint;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import reactor.netty.resources.ConnectionProvider;
+
+import java.time.Duration;
+
+@ConfigurationProperties("fint.webclient.connection-provider")
+@Component
+@Data
+public class ConnectionProviderSettings {
+    private String type = "fixed";
+    private int maxConnections = ConnectionProvider.DEFAULT_POOL_MAX_CONNECTIONS;
+    private long acquireTimeout = ConnectionProvider.DEFAULT_POOL_ACQUIRE_TIMEOUT;
+    private Duration maxIdleTime;
+    private Duration maxLifeTime;
+}

--- a/src/main/java/no/fint/provisioning/TicketSynchronizingService.java
+++ b/src/main/java/no/fint/provisioning/TicketSynchronizingService.java
@@ -13,6 +13,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -66,25 +67,27 @@ public class TicketSynchronizingService {
 
             if (ticket == null) continue;
 
-            if (ticket.getAttempts().incrementAndGet() > configuration.getTicketSyncMaxRetryAttempts()) {
-                log.debug("Unable to synchronize ticket after 10 retries.");
-                statusCache.put(ticket.getUuid(), TicketStatus.builder().status(TicketStatus.Status.ERROR).build());
-                continue;
-            }
-
             try {
-                Ticket ticketResponse = zenDeskTicketService.createTicket(ticket);
-                statusCache.put(ticket.getUuid(), TicketStatus.builder()
-                        .status(TicketStatus.Status.CREATED)
-                        .ticket(ticketResponse)
-                        .build()
+                Ticket response = zenDeskTicketService
+                        .createTicket(ticket.getTicket())
+                        .block(Duration.ofSeconds(30));
+                statusCache.put(ticket.getUuid(),
+                        TicketStatus
+                                .builder()
+                                .status(TicketStatus.Status.CREATED)
+                                .ticket(response)
+                                .build()
                 );
-                log.info("Ticket #{} created.", ticketResponse.getId());
+                log.info("Ticket #{} created.", response.getId());
                 log.info("Remaining: {}", rateLimiter.getRemaining());
-
             } catch (Exception e) {
-                log.debug("Adding ticket back in queue for retry.", e);
-                ticketQueue.put(ticket);
+                if (ticket.getAttempts().incrementAndGet() >= configuration.getTicketSyncMaxRetryAttempts()) {
+                    log.debug("Unable to synchronize ticket after 10 retries.");
+                    statusCache.put(ticket.getUuid(), TicketStatus.builder().status(TicketStatus.Status.ERROR).build());
+                } else {
+                    log.debug("Adding ticket back in queue for retry.", e);
+                    ticketQueue.offer(ticket);
+                }
                 break;
             }
         } while (rateLimiter.getRemaining() > 0);

--- a/src/main/java/no/fint/provisioning/TicketSynchronizingService.java
+++ b/src/main/java/no/fint/provisioning/TicketSynchronizingService.java
@@ -8,6 +8,7 @@ import no.fint.zendesk.RateLimiter;
 import no.fint.zendesk.ZenDeskTicketService;
 import no.fint.zendesk.model.ticket.Ticket;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 @Service
 @ConditionalOnProperty("fint.zendesk.tickets.enabled")
 public class TicketSynchronizingService {
+
+    @Value("${fint.zendesk.timeout:PT30S}")
+    private Duration timeout;
 
     @Autowired
     private BlockingQueue<TicketSynchronizationObject> ticketQueue;
@@ -70,7 +74,7 @@ public class TicketSynchronizingService {
             try {
                 Ticket response = zenDeskTicketService
                         .createTicket(ticket.getTicket())
-                        .block(Duration.ofSeconds(30));
+                        .block(timeout);
                 statusCache.put(ticket.getUuid(),
                         TicketStatus
                                 .builder()

--- a/src/main/java/no/fint/provisioning/TicketSynchronizingService.java
+++ b/src/main/java/no/fint/provisioning/TicketSynchronizingService.java
@@ -49,9 +49,10 @@ public class TicketSynchronizingService {
         log.info("FINT Zendesk ticket service enabled.");
     }
 
-    @Scheduled(fixedDelayString = "${fint.zendesk.ticket.sync.rate:60000}")
+    @Scheduled(fixedDelayString = "${fint.zendesk.ticket.sync.rate:10000}")
     public void start() {
         if (running.compareAndSet(false, true)) {
+            log.debug("Creating new thread ...");
             new Thread(() -> {
                 try {
                     synchronize();
@@ -67,7 +68,8 @@ public class TicketSynchronizingService {
     private void synchronize() throws InterruptedException {
         log.info("Starting ticket synchronization with {} pending tickets..", ticketQueue.size());
         do {
-            TicketSynchronizationObject ticket = ticketQueue.poll(1, TimeUnit.MINUTES);
+            log.debug("Polling ...");
+            TicketSynchronizationObject ticket = ticketQueue.poll(10, TimeUnit.SECONDS);
 
             if (ticket == null) continue;
 

--- a/src/main/java/no/fint/provisioning/UserSynchronizingService.java
+++ b/src/main/java/no/fint/provisioning/UserSynchronizingService.java
@@ -8,12 +8,12 @@ import no.fint.portal.model.contact.ContactService;
 import no.fint.provisioning.model.UserSynchronizationObject;
 import no.fint.zendesk.RateLimiter;
 import no.fint.zendesk.ZenDeskUserService;
-import no.fint.zendesk.model.user.UserResponse;
+import no.fint.zendesk.model.user.User;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import java.time.Duration;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
@@ -45,21 +45,23 @@ public class UserSynchronizingService {
             if (update == null) break;
             Contact contact = update.getContact();
 
-            if (update.getAttempts().incrementAndGet() > configuration.getUserSyncMaxRetryAttempts()) {
-                log.debug("Unable to synchronize contact {} after 10 retries.", contact.getNin());
-                continue;
-            }
 
             try {
-                UserResponse userResponse = zenDeskUserService.createOrUpdateZenDeskUser(update);
+                User response = zenDeskUserService
+                        .createOrUpdateZenDeskUser(update.getContact())
+                        .block(Duration.ofSeconds(30));
                 log.info("Remaining: {}", rateLimiter.getRemaining());
-                log.info("User ID: {}", userResponse.getUser().getId());
-                contact.setSupportId(String.valueOf(userResponse.getUser().getId()));
+                log.info("User ID: {}", response.getId());
+                contact.setSupportId(String.valueOf(response.getId()));
                 contactService.updateContact(contact);
                 TimeUnit.SECONDS.sleep(1);
-            } catch (WebClientResponseException e) {
-                log.debug("Adding contact back in queue for retry.", e);
-                userSynchronizeQueue.put(update);
+            } catch (Exception e) {
+                if (update.getAttempts().incrementAndGet() >= configuration.getUserSyncMaxRetryAttempts()) {
+                    log.debug("Unable to synchronize contact {} after 10 retries.", contact.getNin());
+                } else {
+                    log.debug("Adding contact back in queue for retry.", e);
+                    userSynchronizeQueue.offer(update);
+                }
                 break;
             }
         } while (rateLimiter.getRemaining() > 1);

--- a/src/main/java/no/fint/provisioning/UserSynchronizingService.java
+++ b/src/main/java/no/fint/provisioning/UserSynchronizingService.java
@@ -10,6 +10,7 @@ import no.fint.zendesk.RateLimiter;
 import no.fint.zendesk.ZenDeskUserService;
 import no.fint.zendesk.model.user.User;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,9 @@ import java.util.concurrent.TimeUnit;
 @Slf4j
 @Component
 public class UserSynchronizingService {
+
+    @Value("${fint.zendesk.timeout:PT30S}")
+    private Duration timeout;
 
     @Autowired
     private ZenDeskUserService zenDeskUserService;
@@ -49,7 +53,7 @@ public class UserSynchronizingService {
             try {
                 User response = zenDeskUserService
                         .createOrUpdateZenDeskUser(update.getContact())
-                        .block(Duration.ofSeconds(30));
+                        .block(timeout);
                 log.info("Remaining: {}", rateLimiter.getRemaining());
                 log.info("User ID: {}", response.getId());
                 contact.setSupportId(String.valueOf(response.getId()));

--- a/src/main/java/no/fint/zendesk/ZenDeskTicketService.java
+++ b/src/main/java/no/fint/zendesk/ZenDeskTicketService.java
@@ -1,7 +1,6 @@
 package no.fint.zendesk;
 
 import lombok.extern.slf4j.Slf4j;
-import no.fint.provisioning.model.TicketSynchronizationObject;
 import no.fint.zendesk.model.ticket.Ticket;
 import no.fint.zendesk.model.ticket.TicketRequest;
 import no.fint.zendesk.model.ticket.TicketResponse;
@@ -18,14 +17,10 @@ public class ZenDeskTicketService {
     @Autowired
     private WebClient webClient;
 
-
-    public Ticket createTicket(TicketSynchronizationObject ticketSynchronizationObject) {
-        Ticket ticket = ticketSynchronizationObject.getTicket();
-        log.debug("Creating ticket.");
-        log.debug("\tAttempt: {}", ticketSynchronizationObject.getAttempts());
-        TicketResponse ticketResponse = webClient.post()
+    public Mono<Ticket> createTicket(Ticket ticket) {
+        return webClient.post()
                 .uri("tickets.json")
-                .syncBody(new TicketRequest(ticket))
+                .bodyValue(new TicketRequest(ticket))
                 .retrieve()
                 .bodyToMono(TicketResponse.class)
                 .onErrorResume(response -> {
@@ -34,8 +29,6 @@ public class ZenDeskTicketService {
                     }
                     return Mono.error(response);
                 })
-                .block();
-
-        return ticketResponse.getTicket();
+                .map(TicketResponse::getTicket);
     }
 }

--- a/src/main/java/no/fint/zendesk/ZenDeskTicketService.java
+++ b/src/main/java/no/fint/zendesk/ZenDeskTicketService.java
@@ -20,7 +20,7 @@ public class ZenDeskTicketService {
     public Mono<Ticket> createTicket(Ticket ticket) {
         return webClient.post()
                 .uri("tickets.json")
-                .bodyValue(new TicketRequest(ticket))
+                .syncBody(new TicketRequest(ticket))
                 .retrieve()
                 .bodyToMono(TicketResponse.class)
                 .onErrorResume(response -> {

--- a/src/main/java/no/fint/zendesk/ZenDeskUserService.java
+++ b/src/main/java/no/fint/zendesk/ZenDeskUserService.java
@@ -29,7 +29,7 @@ public class ZenDeskUserService {
     public Mono<User> createOrUpdateZenDeskUser(Contact contact) {
         return webClient.post()
                 .uri("users/create_or_update.json")
-                .bodyValue(new UserRequest(contactToZenDeskUser(contact)))
+                .syncBody(new UserRequest(contactToZenDeskUser(contact)))
                 .retrieve()
                 .bodyToMono(UserResponse.class)
                 .onErrorResume(response -> {

--- a/src/main/java/no/fint/zendesk/ZenDeskUserService.java
+++ b/src/main/java/no/fint/zendesk/ZenDeskUserService.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import no.fint.portal.model.contact.Contact;
 import no.fint.portal.model.organisation.Organisation;
 import no.fint.portal.model.organisation.OrganisationService;
-import no.fint.provisioning.model.UserSynchronizationObject;
 import no.fint.zendesk.model.user.User;
 import no.fint.zendesk.model.user.UserRequest;
 import no.fint.zendesk.model.user.UserResponse;
@@ -27,14 +26,10 @@ public class ZenDeskUserService {
     @Autowired
     private WebClient webClient;
 
-    public UserResponse createOrUpdateZenDeskUser(UserSynchronizationObject userSynchronizationObject) {
-        Contact contact = userSynchronizationObject.getContact();
-        log.debug("Updating contact {}", contact.getNin());
-        log.debug("\tAttempt: {}", userSynchronizationObject.getAttempts());
-
+    public Mono<User> createOrUpdateZenDeskUser(Contact contact) {
         return webClient.post()
                 .uri("users/create_or_update.json")
-                .syncBody(new UserRequest(contactToZenDeskUser(contact)))
+                .bodyValue(new UserRequest(contactToZenDeskUser(contact)))
                 .retrieve()
                 .bodyToMono(UserResponse.class)
                 .onErrorResume(response -> {
@@ -43,13 +38,13 @@ public class ZenDeskUserService {
                     }
                     return Mono.error(response);
                 })
-                .block();
+                .map(UserResponse::getUser);
     }
 
-    public void deleteZenDeskUser(String id) {
+    public Mono<User> deleteZenDeskUser(String id) {
         log.debug("Deleting user {}", id);
 
-        webClient.delete()
+        return webClient.delete()
                 .uri(String.format("users/%s.json", id))
                 .retrieve()
                 .bodyToMono(UserResponse.class)
@@ -59,7 +54,7 @@ public class ZenDeskUserService {
                     }
                     return Mono.error(response);
                 })
-                .block();
+                .map(UserResponse::getUser);
     }
 
     private User contactToZenDeskUser(Contact contact) {

--- a/src/test/groovy/no/fint/provisioning/TicketQueuingServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provisioning/TicketQueuingServiceSpec.groovy
@@ -2,7 +2,6 @@ package no.fint.provisioning
 
 import no.fint.ApplicationConfiguration
 import no.fint.provisioning.model.TicketSynchronizationObject
-import no.fint.zendesk.model.ticket.Ticket
 import spock.lang.Specification
 
 class TicketQueuingServiceSpec extends Specification {

--- a/src/test/groovy/no/fint/provisioning/TicketSynchronizingServiceSpec.groovy
+++ b/src/test/groovy/no/fint/provisioning/TicketSynchronizingServiceSpec.groovy
@@ -8,9 +8,6 @@ import no.fint.zendesk.model.ticket.Ticket
 import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Mono
-import reactor.core.scheduler.Scheduler
-import reactor.core.scheduler.Schedulers
-import spock.lang.Ignore
 import spock.lang.Specification
 
 import java.util.concurrent.BlockingQueue

--- a/src/test/groovy/no/fint/zendesk/ZenDeskTicketServiceSpec.groovy
+++ b/src/test/groovy/no/fint/zendesk/ZenDeskTicketServiceSpec.groovy
@@ -1,6 +1,6 @@
 package no.fint.zendesk
 
-import no.fint.provisioning.model.TicketSynchronizationObject
+
 import no.fint.zendesk.model.ticket.Ticket
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -28,7 +28,7 @@ class ZenDeskTicketServiceSpec extends Specification {
         )
 
         when:
-        zenDeskTicketService.createTicket(new TicketSynchronizationObject(new Ticket()))
+        zenDeskTicketService.createTicket(new Ticket())
 
         then:
         noExceptionThrown()
@@ -38,7 +38,7 @@ class ZenDeskTicketServiceSpec extends Specification {
         server.enqueue(new MockResponse().setResponseCode(HttpStatus.UNPROCESSABLE_ENTITY.value()))
 
         when:
-        zenDeskTicketService.createTicket(new TicketSynchronizationObject(new Ticket()))
+        zenDeskTicketService.createTicket(new Ticket()).block()
 
         then:
         thrown(WebClientResponseException)

--- a/src/test/groovy/no/fint/zendesk/ZenDeskUserServiceSpec.groovy
+++ b/src/test/groovy/no/fint/zendesk/ZenDeskUserServiceSpec.groovy
@@ -32,7 +32,7 @@ class ZenDeskUserServiceSpec extends Specification {
         )
 
         when:
-        zenDeskUserService.createOrUpdateZenDeskUser(userSynchronizationObject)
+        zenDeskUserService.createOrUpdateZenDeskUser(contact)
 
         then:
         noExceptionThrown()
@@ -43,7 +43,7 @@ class ZenDeskUserServiceSpec extends Specification {
         server.enqueue(new MockResponse().setResponseCode(HttpStatus.UNPROCESSABLE_ENTITY.value()))
 
         when:
-        zenDeskUserService.createOrUpdateZenDeskUser(userSynchronizationObject)
+        zenDeskUserService.createOrUpdateZenDeskUser(contact).block()
 
         then:
         thrown(WebClientResponseException)
@@ -65,7 +65,7 @@ class ZenDeskUserServiceSpec extends Specification {
         server.enqueue(new MockResponse().setResponseCode(HttpStatus.NOT_FOUND.value()))
 
         when:
-        zenDeskUserService.deleteZenDeskUser("123")
+        zenDeskUserService.deleteZenDeskUser("123").block()
 
         then:
         thrown(WebClientResponseException)


### PR DESCRIPTION
Services return Mono instances which are blocked on the caller side.

Cleaned up function argument types.